### PR TITLE
FIX help for toml files with dirs in config path

### DIFF
--- a/toml/toml.go
+++ b/toml/toml.go
@@ -61,8 +61,7 @@ func SaveTOML(config interface{}) (err error) {
 
 // PrepareHelp return help string for this file format.
 func PrepareHelp(config interface{}) (help string, err error) {
-	configFile := goConfig.Path + goConfig.File
-	tmpFile, err := ioutil.TempFile(os.TempDir(), configFile)
+	tmpFile, err := ioutil.TempFile(os.TempDir(), goConfig.File)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
ioutil.TempFile fails when there's no matching directory structure for config path